### PR TITLE
Implement redirect of shortened url to original target.

### DIFF
--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -11,9 +11,16 @@ class UrlsController < ApplicationController
 
   def reroute
     @params = reroute_params[:path]
+    @status = "Not found"
+    target = Url.find_by(shortened: @params)
+    if target
+      #Do all the statistics thingy at this point
+      redirect_to (target.original) if target.active
+      @status = "Inactive"
+    end
 
     # redirect_to ("http://andela.com")
-    render :index
+    # render :index
     # render :inactive
     # render :404
   end

--- a/app/helpers/urls_helper.rb
+++ b/app/helpers/urls_helper.rb
@@ -1,10 +1,11 @@
 module UrlsHelper
   def create_shortened_url (url_id)
-      host_url + "/" + url_id.to_s(32).reverse
+      # host_url + "/" + url_id.to_s(32).reverse
+      url_id.to_s(32).reverse
   end
 
   def host_url
-    request.base_url
+    request.base_url + "/"
   end
 
   def sanitize_url(url)

--- a/app/views/urls/new.html.erb
+++ b/app/views/urls/new.html.erb
@@ -1,13 +1,17 @@
 <h1>New Url</h1>
 <p id="notice"><%= notice %></p>
 <%= render 'form' %>
-<h2>Recent Urls</h2>
-<% @urls.each do |url| %>
-  <p id="<%= dom_id(url) %>"><strong>Original: <%= url.original %></strong>&emsp;
-     <strong>Shortened: <%= url.shortened %></strong>&emsp;
-     <strong>Active: <%= url.active %></strong>
-     <strong>Views: <%= url.views %></strong>
-  </p>
+<% if @urls %>
+  <h2>Recent Urls</h2>
+  <ul>
+  <% @urls.each do |url| %>
+    <li id="<%= dom_id(url) %>"><strong>Original: <%= url.original %></strong>&emsp;
+       <strong>Shortened: <%= host_url + url.shortened %></strong>&emsp;
+       <strong>Active: <%= url.active %></strong>
+       <strong>Views: <%= url.views %></strong>
+    </li>
+  <% end %>
+  </ul>
 <% end %>
 
 <% if @popular_urls %>
@@ -16,7 +20,7 @@
   <ul>
   <% @popular_urls.each do |url| %>
     <li id="<%= dom_id(url) %>"><strong>Original: <%= url.original %></strong>&emsp;
-       <strong>Shortened: <%= url.shortened %></strong>&emsp;
+       <strong>Shortened: <%= host_url + url.shortened %></strong>&emsp;
        <strong>Active: <%= url.active %></strong>
        <strong>Views: <%= url.views %></strong>
     </li>

--- a/app/views/urls/reroute.html.erb
+++ b/app/views/urls/reroute.html.erb
@@ -1,0 +1,6 @@
+<p>THIS IS REROUTE ERB</p>
+
+<p>THIS IS PAGE IS SHOWN ONLY FOR INVALID</p>
+
+<p><%= @status %></p>
+<p><%= @params %></p>

--- a/spec/features/urls/popular_url_spec.rb
+++ b/spec/features/urls/popular_url_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe "Visiting the homepage" do
+  Url.delete_all
+  def generate_url(amount = 20,   views = nil)
+    amount.times do
+      views ||= rand(1..10)
+      Url.create(original: Faker::Internet.url, views: views)
+    end
+    visit "/urls/new"
+  end
+
+  # it "displays nothing if db is empty" do
+  #   visit "/urls/new"
+  #   within "div.popular_urls" do
+  #     within("h2") do
+  #       expect(page).to_not have_content("Popular Urls")
+  #     end
+  #     # expect(("ul li").size).to eq(0)
+  #   end
+  # end
+
+  describe "if db is not empty" do
+    # it "displays popular urls" do
+    #   generate_url(10)
+    #   within "div .popular_urls" do
+    #     within("h2") do
+    #       expect(page).to have_content("Popular Urls")
+    #     end
+    #     expect(("ul li").size).to eq(10)
+    #   end
+    # end
+  #
+    it "displays the Url with the most view" do
+      expect(Url.count).to eql(0)
+      generate_url(20, 50)
+      visit "/urls/new"
+    end
+  #
+  #   it "displays maximum of 20 Url" do
+  #
+  #   end
+  end
+end

--- a/spec/features/urls/reroute_url_spec.rb
+++ b/spec/features/urls/reroute_url_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe "Rerouting Urls" do
+  it "redirects to the original url if valid shortened url" do
+  end
+
+  it "shows inactive notice for shortened url that are inactive" do
+  end
+
+  it "shows not found notice for url that have not been shortened" do
+  end
+
+  it  "shows not found notice for anyother invalid entry or empty request" do
+  end
+end
+s


### PR DESCRIPTION
This change implements the actually redirection of shortened urls to the original target url. It also includes basic checks for invalid entries such as emails that haven't been shortened, urls that have been deactivated and/or other invalid redirect requests. It also includes test stubs for the aforementioned features.
